### PR TITLE
Enable admin credential sign-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,7 +50,6 @@ dist/
 public/build/
 public/dist/
 release/
-lib/
 compiled/
 .next/
 out/

--- a/README.md
+++ b/README.md
@@ -56,7 +56,18 @@ Edit `.env.local` with your actual values:
 - Google Analytics Measurement ID
 - OAuth credentials (will be configured later)
 
-### 4. Run Development Server
+### 4. Apply Database Migrations and Seed Admin User
+
+Make sure your `.env.local` includes a valid `DATABASE_URL`, then run:
+
+```bash
+npx prisma migrate dev
+npm run db:seed
+```
+
+This applies the latest schema (including email/password support) and ensures the default admin account exists.
+
+### 5. Run Development Server
 
 ```bash
 npm run dev
@@ -64,7 +75,7 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000) in your browser.
 
-### 5. Build for Production
+### 6. Build for Production
 
 ```bash
 npm run build
@@ -125,6 +136,13 @@ npm run lint
 ## 🧪 Testing
 
 Testing will be implemented in future tasks.
+
+## 🔐 Default Admin Login
+
+- Username: `tkhongsap`
+- Password: `sthought`
+
+You can override these by setting `ADMIN_EMAIL`, `ADMIN_NAME`, `ADMIN_PASSWORD`, or `ADMIN_PASSWORD_HASH` in `.env.local` before running `npm run db:seed`.
 
 ## 📚 Documentation
 

--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { signIn } from '@/auth';
+import type { SignInResponse } from 'next-auth/react';
 
 export async function signInAction(provider: string) {
   await signIn(provider, { 
@@ -10,20 +11,22 @@ export async function signInAction(provider: string) {
 
 export async function devBypassSignInAction() {
   console.log('[Dev Bypass] Signing in admin user...');
-  
+
   try {
-    await signIn('credentials', { 
+    const result = (await signIn('credentials', {
       email: 'tkhongsap',
       password: 'sthought',
+      redirect: false,
       redirectTo: '/dashboard',
-    });
+    })) as SignInResponse | undefined;
     console.log('[Dev Bypass] Sign in successful');
-    return { success: true };
+    const redirectTo = result?.url ?? '/dashboard';
+    return { success: true, redirectTo };
   } catch (error) {
     console.error('[Dev Bypass] Sign-in error:', error);
-    return { 
-      success: false, 
-      error: 'ไม่สามารถเข้าสู่ระบบได้' 
+    return {
+      success: false,
+      error: 'ไม่สามารถเข้าสู่ระบบได้'
     };
   }
 }
@@ -32,22 +35,24 @@ export async function credentialsSignInAction(email: string, password: string) {
   console.log('[Server Action] credentialsSignInAction called');
   console.log('[Server Action] Email:', email);
   console.log('[Server Action] Password length:', password?.length);
-  
+
   try {
     console.log('[Server Action] Calling signIn with credentials...');
-    await signIn('credentials', { 
+    const result = (await signIn('credentials', {
       email,
       password,
+      redirect: false,
       redirectTo: '/auth/grade-selection',
-    });
+    })) as SignInResponse | undefined;
     console.log('[Server Action] signIn successful');
-    return { success: true };
+    const redirectTo = result?.url ?? '/auth/grade-selection';
+    return { success: true, redirectTo };
   } catch (error) {
     console.error('[Server Action] Credentials sign-in error:', error);
     console.error('[Server Action] Error details:', JSON.stringify(error, null, 2));
-    return { 
-      success: false, 
-      error: 'อีเมลหรือรหัสผ่านไม่ถูกต้อง' 
+    return {
+      success: false,
+      error: 'อีเมลหรือรหัสผ่านไม่ถูกต้อง'
     };
   }
 }

--- a/components/ui/CredentialsSignInForm.tsx
+++ b/components/ui/CredentialsSignInForm.tsx
@@ -1,31 +1,71 @@
 'use client';
 
-import { useState } from 'react';
-import { devBypassSignInAction } from '@/app/actions/auth';
+import { FormEvent, useState } from 'react';
+import { credentialsSignInAction, devBypassSignInAction } from '@/app/actions/auth';
 
 interface CredentialsSignInFormProps {
   className?: string;
 }
 
 export default function CredentialsSignInForm({ className = '' }: CredentialsSignInFormProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [devLoading, setDevLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  const isDevEnvironment = process.env.NODE_ENV !== 'production';
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (loading) {
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const result = await credentialsSignInAction(email.trim(), password);
+
+      if (!result?.success) {
+        setError(result?.error || 'อีเมลหรือรหัสผ่านไม่ถูกต้อง');
+        setLoading(false);
+        return;
+      }
+
+      const redirectTo = result.redirectTo ?? '/auth/grade-selection';
+      window.location.href = redirectTo;
+    } catch (err) {
+      console.error('[CredentialsSignInForm] Sign-in failed', err);
+      setError('เกิดข้อผิดพลาดในการเข้าสู่ระบบ');
+      setLoading(false);
+    }
+  };
 
   const handleBypassLogin = async () => {
     setError(null);
-    setLoading(true);
+    setDevLoading(true);
 
     try {
       const result = await devBypassSignInAction();
       if (!result.success) {
         setError(result.error || 'เกิดข้อผิดพลาด');
+        setDevLoading(false);
+        return;
       }
+
+      const redirectTo = result.redirectTo ?? '/dashboard';
+      window.location.href = redirectTo;
     } catch (err) {
+      console.error('[CredentialsSignInForm] Dev bypass failed', err);
       setError('เกิดข้อผิดพลาดในการเข้าสู่ระบบ');
-    } finally {
-      setLoading(false);
+      setDevLoading(false);
     }
   };
+
+  const submitDisabled = loading || !email.trim() || !password;
 
   return (
     <div className={`space-y-4 ${className}`}>
@@ -35,23 +75,81 @@ export default function CredentialsSignInForm({ className = '' }: CredentialsSig
         </div>
       )}
 
-      <button
-        onClick={handleBypassLogin}
-        disabled={loading}
-        className="w-full bg-primary hover:bg-primary-dark text-white font-medium px-6 py-3 rounded-lg transition-all duration-200 shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center"
-      >
-        {loading ? (
-          <>
-            <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-            </svg>
-            กำลังเข้าสู่ระบบ...
-          </>
-        ) : (
-          'เข้าสู่ระบบแบบ Dev (Bypass)'
-        )}
-      </button>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2 text-left">
+          <label htmlFor="credentials-email" className="block text-sm font-medium">
+            อีเมลหรือชื่อผู้ใช้
+          </label>
+          <input
+            id="credentials-email"
+            type="text"
+            inputMode="email"
+            autoComplete="username"
+            placeholder="เช่น tkhongsap"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            className="w-full rounded-lg border border-gray-200 px-4 py-3 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/40 outline-none transition-all"
+            disabled={loading}
+            required
+          />
+        </div>
+
+        <div className="space-y-2 text-left">
+          <label htmlFor="credentials-password" className="block text-sm font-medium">
+            รหัสผ่าน
+          </label>
+          <input
+            id="credentials-password"
+            type="password"
+            autoComplete="current-password"
+            placeholder="กรอกรหัสผ่านของคุณ"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            className="w-full rounded-lg border border-gray-200 px-4 py-3 text-sm text-gray-900 focus:border-primary focus:ring-2 focus:ring-primary/40 outline-none transition-all"
+            disabled={loading}
+            required
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={submitDisabled}
+          className="w-full bg-primary hover:bg-primary-dark text-white font-medium px-6 py-3 rounded-lg transition-all duration-200 shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center"
+        >
+          {loading ? (
+            <>
+              <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              กำลังเข้าสู่ระบบ...
+            </>
+          ) : (
+            'เข้าสู่ระบบ'
+          )}
+        </button>
+      </form>
+
+      {isDevEnvironment && (
+        <button
+          type="button"
+          onClick={handleBypassLogin}
+          disabled={devLoading}
+          className="w-full bg-gray-100 hover:bg-gray-200 text-gray-900 font-medium px-6 py-3 rounded-lg transition-all duration-200 shadow-sm hover:shadow disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center"
+        >
+          {devLoading ? (
+            <>
+              <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-gray-700" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+              </svg>
+              กำลังเข้าสู่ระบบแบบทดสอบ...
+            </>
+          ) : (
+            'เข้าสู่ระบบแบบ Dev (Bypass)'
+          )}
+        </button>
+      )}
     </div>
   );
 }

--- a/env.local.example
+++ b/env.local.example
@@ -17,3 +17,9 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # Note: Copy this file to .env.local and fill in your actual values
 # Never commit .env.local to version control
 
+# Optional: Override default admin credentials used for local testing
+# ADMIN_EMAIL=tkhongsap
+# ADMIN_NAME=Sanook Admin
+# ADMIN_PASSWORD=sthought
+# ADMIN_PASSWORD_HASH= # Provide a bcrypt hash instead of ADMIN_PASSWORD if preferred
+

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,82 @@
+/* eslint-disable no-console */
+const isBrowser = typeof window !== 'undefined';
+const isDev = process.env.NODE_ENV !== 'production';
+
+function emitEvent(eventName: string, params: Record<string, unknown>) {
+  if (!isBrowser) {
+    return;
+  }
+
+  const gtag = (window as typeof window & { gtag?: (...args: unknown[]) => void }).gtag;
+
+  if (typeof gtag === 'function') {
+    gtag('event', eventName, params);
+    return;
+  }
+
+  if (isDev) {
+    console.log(`[Analytics] ${eventName}`, params);
+  }
+}
+
+export function trackCTAClick(location: string, provider: string) {
+  emitEvent('cta_click', {
+    cta_location: location,
+    auth_provider: provider,
+    event_category: 'engagement',
+    event_label: `${location}_${provider}`,
+  });
+}
+
+export function trackSignUpStarted(provider: string) {
+  emitEvent('sign_up_started', {
+    auth_provider: provider,
+    event_category: 'conversion',
+  });
+}
+
+export function trackSignUpCompleted(provider: string) {
+  emitEvent('sign_up_completed', {
+    auth_provider: provider,
+    event_category: 'conversion',
+  });
+}
+
+export function trackError(errorType: string, message: string, provider?: string) {
+  emitEvent('error', {
+    error_type: errorType,
+    error_message: message,
+    auth_provider: provider,
+    event_category: 'error',
+  });
+}
+
+export function trackFAQInteraction(questionId: string, questionText: string, action: 'expand' | 'collapse') {
+  emitEvent('faq_interaction', {
+    question_id: questionId,
+    question_text: questionText,
+    action,
+    event_category: 'engagement',
+  });
+}
+
+export function trackScrollDepth(sectionName: string, depthPercentage: number) {
+  emitEvent('scroll_depth', {
+    section_name: sectionName,
+    depth_percentage: depthPercentage,
+    event_category: 'engagement',
+  });
+}
+
+export function trackSectionView(sectionName: string) {
+  emitEvent('section_view', {
+    section_name: sectionName,
+    event_category: 'engagement',
+  });
+}
+
+export function trackPageView(path: string) {
+  emitEvent('page_view', {
+    page_path: path,
+  });
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { signInAction } from '@/app/actions/auth';
+
+export type AuthProvider = 'google' | 'facebook';
+
+export interface AuthError {
+  code: string;
+  message: string;
+  provider?: AuthProvider;
+}
+
+const errorMessages: Record<string, string> = {
+  popup_blocked: 'กรุณาอนุญาตให้เบราว์เซอร์เปิดหน้าต่างใหม่เพื่อดำเนินการต่อ',
+  popup_closed: 'คุณปิดหน้าต่างเข้าสู่ระบบก่อนเสร็จสิ้น โปรดลองอีกครั้ง',
+  network_error: 'การเชื่อมต่อขัดข้อง กรุณาตรวจสอบอินเทอร์เน็ตแล้วลองใหม่',
+  auth_failed: 'ไม่สามารถเข้าสู่ระบบได้ กรุณาลองใหม่อีกครั้ง',
+  permission_denied: 'คุณปฏิเสธการขออนุญาต กรุณาอนุมัติการเข้าถึงข้อมูลที่จำเป็น',
+};
+
+export async function initiateOAuthSignIn(provider: AuthProvider) {
+  try {
+    await signInAction(provider);
+  } catch (error) {
+    console.error('[Auth] Failed to initiate OAuth sign-in', error);
+    throw error;
+  }
+}
+
+export function getAuthErrorMessage(error: AuthError): string {
+  if (!error) {
+    return 'ไม่สามารถเข้าสู่ระบบได้ในขณะนี้';
+  }
+
+  return (
+    errorMessages[error.code] ||
+    error.message ||
+    'ไม่สามารถเข้าสู่ระบบได้ในขณะนี้'
+  );
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,14 @@
+import { PrismaClient } from './generated/prisma';
+
+declare global {
+  // eslint-disable-next-line no-var
+  var prisma: PrismaClient | undefined;
+}
+
+const prismaClient = globalThis.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalThis.prisma = prismaClient;
+}
+
+export const prisma = prismaClient;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev -p 5000",
     "build": "next build",
     "start": "next start -p 5000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "db:seed": "prisma db seed"
   },
   "repository": {
     "type": "git",
@@ -39,6 +40,9 @@
     "react-dom": "^19.2.0",
     "typescript": "^5.9.3",
     "ws": "^8.18.3"
+  },
+  "prisma": {
+    "seed": "node prisma/seed.js"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",

--- a/prisma/migrations/20251007160000_add_credentials_fields/migration.sql
+++ b/prisma/migrations/20251007160000_add_credentials_fields/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "users"
+  ALTER COLUMN "socialProvider" DROP NOT NULL,
+  ALTER COLUMN "socialProviderId" DROP NOT NULL;
+
+ALTER TABLE "users"
+  ADD COLUMN     "password" TEXT,
+  ADD COLUMN     "isAdmin" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,45 @@
+const { PrismaClient } = require('../lib/generated/prisma');
+const bcrypt = require('bcryptjs');
+
+const prisma = new PrismaClient();
+
+async function ensureAdminUser() {
+  const adminEmail = process.env.ADMIN_EMAIL ?? 'tkhongsap';
+  const adminName = process.env.ADMIN_NAME ?? 'Sanook Admin';
+  const adminPasswordHash = process.env.ADMIN_PASSWORD_HASH;
+  const adminPassword = process.env.ADMIN_PASSWORD ?? 'sthought';
+
+  const passwordToStore = adminPasswordHash
+    ? adminPasswordHash
+    : await bcrypt.hash(adminPassword, 12);
+
+  const user = await prisma.user.upsert({
+    where: { email: adminEmail },
+    update: {
+      name: adminName,
+      password: passwordToStore,
+      isAdmin: true,
+    },
+    create: {
+      email: adminEmail,
+      name: adminName,
+      password: passwordToStore,
+      isAdmin: true,
+    },
+  });
+
+  console.log(`✅ Admin user ready: ${user.email}`);
+}
+
+async function main() {
+  await ensureAdminUser();
+}
+
+main()
+  .catch((error) => {
+    console.error('❌ Failed to seed database', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/replit.md
+++ b/replit.md
@@ -17,7 +17,7 @@ Sanook Kids Learning is a free Thai educational platform for Grade 4 (ป.4) and
 - Secure password hashing with bcryptjs
 - Admin account support with isAdmin flag
 - Dual login UI with tab-based interface (Google / Email)
-- Admin account created: `tkhongsap` (for testing and development)
+- Admin account created: `tkhongsap` (ensure by running `npm run db:seed`)
 
 ### October 6, 2025 - User Authentication System Complete (PRD 0001)
 
@@ -133,6 +133,7 @@ Sanook Kids Learning is a free Thai educational platform for Grade 4 (ป.4) and
 - Email: `tkhongsap`
 - Password: `sthought`
 - Has `isAdmin: true` flag for special privileges
+- Seed locally with `npm run db:seed` (supports overrides via admin-related env vars)
 
 ### Route Protection (Middleware)
 


### PR DESCRIPTION
## Summary
- replace the dev-only bypass button with a real email/password form that calls the credentials sign-in action and redirects after success
- adjust the credentials server actions to use `redirect: false`, returning the target URL instead of swallowing the NextAuth redirect
- restore the shared analytics and auth helpers so client components compile and GA events/no-op logging work again

## Testing
- npm run lint
- Manual Playwright flow exercising credential login

------
https://chatgpt.com/codex/tasks/task_e_68e728780c3483329cf1490bf96a3c9e