### PR TITLE
Fix dev bypass middleware auth resolution

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -9,28 +9,6 @@ export async function signInAction(provider: string) {
   });
 }
 
-export async function devBypassSignInAction() {
-  console.log('[Dev Bypass] Signing in admin user...');
-
-  try {
-    const result = (await signIn('credentials', {
-      email: 'tkhongsap',
-      password: 'sthought',
-      redirect: false,
-      redirectTo: '/auth/grade-selection',
-    })) as SignInResponse | undefined;
-    console.log('[Dev Bypass] Sign in successful');
-    const redirectTo = result?.url ?? '/auth/grade-selection';
-    return { success: true, redirectTo };
-  } catch (error) {
-    console.error('[Dev Bypass] Sign-in error:', error);
-    return {
-      success: false,
-      error: 'ไม่สามารถเข้าสู่ระบบได้'
-    };
-  }
-}
-
 export async function credentialsSignInAction(email: string, password: string) {
   console.log('[Server Action] credentialsSignInAction called');
   console.log('[Server Action] Email:', email);

--- a/auth.ts
+++ b/auth.ts
@@ -3,7 +3,17 @@ import Google from 'next-auth/providers/google';
 import Credentials from 'next-auth/providers/credentials';
 import { PrismaClient, SocialProvider, GradeLevel } from './lib/generated/prisma';
 import { prisma } from './lib/db';
-import bcrypt from 'bcryptjs';
+type BcryptModule = typeof import('bcryptjs');
+
+let cachedBcrypt: BcryptModule | null = null;
+
+async function getBcrypt(): Promise<BcryptModule> {
+  if (!cachedBcrypt) {
+    cachedBcrypt = await import('bcryptjs');
+  }
+
+  return cachedBcrypt;
+}
 
 declare module 'next-auth' {
   interface Session extends DefaultSession {
@@ -77,6 +87,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
 
         console.log('[Auth Debug] Comparing password...');
+        const bcrypt = await getBcrypt();
         const isPasswordValid = await bcrypt.compare(
           credentials.password as string,
           user.password

--- a/components/ui/CredentialsSignInForm.tsx
+++ b/components/ui/CredentialsSignInForm.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import { FormEvent, useState } from 'react';
-import { credentialsSignInAction, devBypassSignInAction } from '@/app/actions/auth';
+import { useRouter } from 'next/navigation';
+import { credentialsSignInAction } from '@/app/actions/auth';
 
 interface CredentialsSignInFormProps {
   className?: string;
 }
 
 export default function CredentialsSignInForm({ className = '' }: CredentialsSignInFormProps) {
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -44,22 +46,15 @@ export default function CredentialsSignInForm({ className = '' }: CredentialsSig
     }
   };
 
-  const handleBypassLogin = async () => {
+  const handleBypassLogin = () => {
     setError(null);
     setDevLoading(true);
 
     try {
-      const result = await devBypassSignInAction();
-      if (!result.success) {
-        setError(result.error || 'เกิดข้อผิดพลาด');
-        setDevLoading(false);
-        return;
-      }
-
-      const redirectTo = result.redirectTo ?? '/dashboard';
-      window.location.href = redirectTo;
+      document.cookie = 'dev-bypass=grade-selection; path=/; max-age=3600';
+      router.push('/auth/grade-selection');
     } catch (err) {
-      console.error('[CredentialsSignInForm] Dev bypass failed', err);
+      console.error('[CredentialsSignInForm] Dev bypass navigation failed', err);
       setError('เกิดข้อผิดพลาดในการเข้าสู่ระบบ');
       setDevLoading(false);
     }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,41 +1,56 @@
-import { auth } from '@/auth';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
 
-export default auth((req) => {
-  const isAuthenticated = !!req.auth;
+export default async function middleware(req: NextRequest) {
+  const token = await getToken({
+    req,
+    secret: process.env.NEXTAUTH_SECRET,
+    secureCookie: process.env.NODE_ENV === 'production',
+  });
+
+  const isAuthenticated = !!token;
   const { pathname } = req.nextUrl;
+  const devBypassCookie = req.cookies.get('dev-bypass')?.value;
+  const canDevBypassGradeSelection =
+    process.env.NODE_ENV !== 'production' &&
+    devBypassCookie === 'grade-selection' &&
+    pathname.startsWith('/auth/grade-selection');
 
   const protectedRoutes = ['/dashboard', '/lessons', '/auth/grade-selection'];
   const isProtectedRoute = protectedRoutes.some(route => pathname.startsWith(route));
 
   if (!isAuthenticated && isProtectedRoute) {
+    if (canDevBypassGradeSelection) {
+      return NextResponse.next();
+    }
+
     const url = new URL('/', req.url);
     return NextResponse.redirect(url);
   }
 
-  if (isAuthenticated && req.auth?.user) {
-    const user = req.auth.user;
-    
+  if (isAuthenticated) {
+    const gradeLevel = token?.gradeLevel as string | null | undefined;
+
     if (pathname === '/') {
-      if (user.gradeLevel) {
+      if (gradeLevel) {
         return NextResponse.redirect(new URL('/dashboard', req.url));
-      } else {
-        return NextResponse.redirect(new URL('/auth/grade-selection', req.url));
       }
+
+      return NextResponse.redirect(new URL('/auth/grade-selection', req.url));
     }
 
-    if (pathname.startsWith('/auth/grade-selection') && user.gradeLevel) {
+    if (pathname.startsWith('/auth/grade-selection') && gradeLevel) {
       return NextResponse.redirect(new URL('/dashboard', req.url));
     }
 
-    if (pathname.startsWith('/dashboard') && !user.gradeLevel) {
+    if (pathname.startsWith('/dashboard') && !gradeLevel) {
       return NextResponse.redirect(new URL('/auth/grade-selection', req.url));
     }
   }
 
   return NextResponse.next();
-});
+}
 
 export const config = {
   matcher: ['/', '/dashboard/:path*', '/lessons/:path*', '/auth/grade-selection'],


### PR DESCRIPTION
## Summary
- lazily load bcrypt for the credentials provider so auth.ts no longer blocks middleware bundling
- refactor middleware to use next-auth JWT tokens while still honoring the dev bypass cookie for grade selection
- verify the Dev Bypass button now reaches the grade selection screen without logging in

## Testing
- npm run lint
- npm run dev -- --hostname 0.0.0.0 --port 5000

------
https://chatgpt.com/codex/tasks/task_e_68e7650e57c88332aef3cb4b1c7a672b