### PR TITLE
Fix dev bypass to log in without server action errors

### DIFF
--- a/app/actions/auth.ts
+++ b/app/actions/auth.ts
@@ -2,6 +2,7 @@
 
 import { signIn } from '@/auth';
 import type { SignInResponse } from 'next-auth/react';
+import { DEV_BYPASS_EMAIL, DEV_BYPASS_PASSWORD } from '@/lib/dev-bypass';
 
 export async function signInAction(provider: string) {
   await signIn(provider, { 
@@ -14,13 +15,14 @@ export async function devBypassSignInAction() {
 
   try {
     const result = (await signIn('credentials', {
-      email: 'tkhongsap',
-      password: 'sthought',
+      email: DEV_BYPASS_EMAIL,
+      password: DEV_BYPASS_PASSWORD,
       redirect: false,
       redirectTo: '/auth/grade-selection',
     })) as SignInResponse | undefined;
     console.log('[Dev Bypass] Sign in successful');
-    return { success: true, redirectTo: '/auth/grade-selection' };
+    const redirectTo = result?.url ?? '/auth/grade-selection';
+    return { success: true, redirectTo };
   } catch (error) {
     console.error('[Dev Bypass] Sign-in error:', error);
     return {

--- a/app/api/dev-bypass/route.ts
+++ b/app/api/dev-bypass/route.ts
@@ -1,27 +1,53 @@
 import { NextResponse } from 'next/server';
-import { signIn } from '@/auth';
+import { prisma } from '@/lib/db';
+import bcrypt from 'bcryptjs';
+import { DEV_BYPASS_EMAIL, DEV_BYPASS_PASSWORD, DEV_BYPASS_NAME } from '@/lib/dev-bypass';
+import { GradeLevel } from '@/lib/generated/prisma';
 
 export async function POST() {
   try {
-    console.log('[Dev Bypass API] Signing in admin user...');
-    
-    await signIn('credentials', {
-      email: 'tkhongsap',
-      password: 'sthought',
-      redirect: false,
-      redirectTo: '/auth/grade-selection',
+    console.log('[Dev Bypass API] Ensuring dev user exists...');
+
+    const existingUser = await prisma.user.findUnique({
+      where: { email: DEV_BYPASS_EMAIL },
     });
 
-    console.log('[Dev Bypass API] Sign in successful');
-    return NextResponse.json({ 
-      success: true, 
-      redirectTo: '/auth/grade-selection' 
+    if (!existingUser) {
+      const hashedPassword = await bcrypt.hash(DEV_BYPASS_PASSWORD, 10);
+
+      await prisma.user.create({
+        data: {
+          email: DEV_BYPASS_EMAIL,
+          name: DEV_BYPASS_NAME,
+          password: hashedPassword,
+          gradeLevels: [] as GradeLevel[],
+          isAdmin: true,
+        },
+      });
+
+      console.log('[Dev Bypass API] Dev user created');
+    } else if (!existingUser.password) {
+      const hashedPassword = await bcrypt.hash(DEV_BYPASS_PASSWORD, 10);
+
+      await prisma.user.update({
+        where: { id: existingUser.id },
+        data: {
+          password: hashedPassword,
+          isAdmin: true,
+        },
+      });
+
+      console.log('[Dev Bypass API] Dev user password seeded');
+    }
+
+    return NextResponse.json({
+      success: true,
     });
   } catch (error) {
     console.error('[Dev Bypass API] Error:', error);
-    return NextResponse.json({ 
-      success: false, 
-      error: 'ไม่สามารถเข้าสู่ระบบได้' 
+    return NextResponse.json({
+      success: false,
+      error: 'ไม่สามารถเข้าสู่ระบบได้'
     }, { status: 500 });
   }
 }

--- a/app/auth/grade-selection/page.tsx
+++ b/app/auth/grade-selection/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 
 type GradeOption = 'GRADE_4' | 'GRADE_6';
@@ -14,7 +13,6 @@ interface GradeCard {
 }
 
 export default function GradeSelectionPage() {
-  const router = useRouter();
   const { update } = useSession();
   const [selectedGrades, setSelectedGrades] = useState<GradeOption[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/lib/dev-bypass.ts
+++ b/lib/dev-bypass.ts
@@ -1,0 +1,3 @@
+export const DEV_BYPASS_EMAIL = process.env.NEXT_PUBLIC_DEV_BYPASS_EMAIL ?? 'tkhongsap';
+export const DEV_BYPASS_PASSWORD = process.env.NEXT_PUBLIC_DEV_BYPASS_PASSWORD ?? 'sthought';
+export const DEV_BYPASS_NAME = process.env.NEXT_PUBLIC_DEV_BYPASS_NAME ?? 'Dev Admin';


### PR DESCRIPTION
## Summary
- ensure the dev bypass API seeds the development credentials user instead of invoking NextAuth server actions directly
- share dev bypass credentials through a reusable helper and call the credentials sign-in flow from client components
- update the landing CTA and credentials form to set up the dev account then sign in, enabling seamless redirects to grade selection

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e76a5ff01083329acdff17b96973a8